### PR TITLE
feat: add DeepSeek balance & usage status bar item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "huggingface-vscode-chat",
-	"version": "0.1.0",
+	"name": "deepseek-copilot",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "huggingface-vscode-chat",
-			"version": "0.1.0",
+			"name": "deepseek-copilot",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
 			{
 				"command": "huggingface.manage",
 				"title": "Manage DeepSeek V4 Pro Provider"
+			},
+			{
+				"command": "huggingface.refreshBalance",
+				"title": "Refresh DeepSeek Balance",
+				"icon": "$(refresh)"
 			}
 		]
 	},

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -1,0 +1,243 @@
+import * as vscode from "vscode";
+
+const BALANCE_API_URL = "https://api.deepseek.com/user/balance";
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const BALANCE_CACHE_STATE_KEY = "deepseek.balanceCache";
+
+/** Balance info for a single currency returned by DeepSeek API. */
+export interface DeepSeekBalanceInfo {
+	currency: string;
+	total_balance: string;
+	granted_balance: string;
+	topped_up_balance: string;
+}
+
+/** Full balance API response. */
+export interface DeepSeekBalanceResponse {
+	is_available: boolean;
+	balance_infos: DeepSeekBalanceInfo[];
+}
+
+/** Cached balance data persisted in globalState. */
+interface CachedBalance {
+	timestamp: number;
+	data: DeepSeekBalanceResponse | null;
+	error?: string;
+}
+
+/**
+ * Fetch the user's balance from the DeepSeek API.
+ * Returns null if the API key is missing.
+ */
+export async function fetchBalance(apiKey: string): Promise<DeepSeekBalanceResponse> {
+	const response = await fetch(BALANCE_API_URL, {
+		method: "GET",
+		headers: {
+			"Accept": "application/json",
+			"Authorization": `Bearer ${apiKey}`,
+		},
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Balance API error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`);
+	}
+
+	return (await response.json()) as DeepSeekBalanceResponse;
+}
+
+/**
+ * Manages a VS Code StatusBarItem that displays DeepSeek balance and
+ * estimated token usage.  The item lives in the bottom-right status bar,
+ * similar to the native Copilot UI.
+ */
+export class BalanceStatusBarManager {
+	private readonly _statusBarItem: vscode.StatusBarItem;
+	private _refreshTimer: ReturnType<typeof setTimeout> | undefined;
+	private _totalInputTokens = 0;
+	private _totalOutputTokens = 0;
+	private _cachedBalance: CachedBalance | null = null;
+
+	constructor(
+		private readonly _getApiKey: () => Promise<string | undefined>,
+		private readonly _globalState: vscode.Memento,
+	) {
+		this._statusBarItem = vscode.window.createStatusBarItem(
+			vscode.StatusBarAlignment.Right,
+			1, // priority — push it toward the right edge (lower number = righter)
+		);
+		this._statusBarItem.name = "DeepSeek Balance";
+		this._statusBarItem.tooltip = "DeepSeek 余额 & 用量";
+		this._statusBarItem.text = "$(loading~spin) DeepSeek";
+		this._statusBarItem.command = "huggingface.refreshBalance";
+		this._statusBarItem.show();
+
+		// Restore cached balance & token counts from previous session
+		const saved = this._globalState.get<CachedBalance>(BALANCE_CACHE_STATE_KEY);
+		if (saved) {
+			this._cachedBalance = saved;
+			this._updateDisplay();
+		}
+
+		// Initial fetch
+		void this._refresh();
+	}
+
+	/** Called by the provider after each successful API call to track usage. */
+	recordUsage(inputTokens: number, outputTokens: number): void {
+		this._totalInputTokens += inputTokens;
+		this._totalOutputTokens += outputTokens;
+		this._updateDisplay();
+	}
+
+	/** Manually refresh balance (e.g. via command). */
+	async refresh(): Promise<void> {
+		await this._refresh();
+	}
+
+	/** Format the status bar compact text. */
+	private _buildCompactText(): string {
+		const balance = this._cachedBalance?.data;
+		if (!balance) {
+			// We still show token usage even if balance hasn't been fetched
+			if (this._totalInputTokens > 0 || this._totalOutputTokens > 0) {
+				return `$(pulse) ${this._formatTokens(this._totalInputTokens + this._totalOutputTokens)}`;
+			}
+			return `$(question) DeepSeek`;
+		}
+
+		if (!balance.is_available) {
+			return `$(warning) DeepSeek 余额不足`;
+		}
+
+		// Find CNY balance (preferred) or first available currency
+		const info = balance.balance_infos.find((b) => b.currency === "CNY")
+			?? balance.balance_infos[0];
+
+		if (!info) {
+			return `$(check) DeepSeek`;
+		}
+
+		const total = parseFloat(info.total_balance);
+		const symbol = info.currency === "CNY" ? "¥" : info.currency;
+
+		// Compact: symbol + total balance
+		return `$(credit-card) ${symbol}${total.toFixed(2)}`;
+	}
+
+	/** Format the full tooltip with detailed info. */
+	private _buildTooltip(): string {
+		const balance = this._cachedBalance?.data;
+		const lines: string[] = ["**DeepSeek 余额 & 用量**", ""];
+
+		if (balance) {
+			if (balance.is_available) {
+				for (const info of balance.balance_infos) {
+					const symbol = info.currency === "CNY" ? "¥" : info.currency;
+					lines.push(`💰 总余额: ${symbol}${info.total_balance}`);
+					lines.push(`   ├ 充值余额: ${symbol}${info.topped_up_balance}`);
+					lines.push(`   └ 赠送余额: ${symbol}${info.granted_balance}`);
+				}
+			} else {
+				lines.push("⚠️ 余额不足，账户已欠费");
+			}
+		} else if (this._cachedBalance?.error) {
+			lines.push(`❌ 获取余额失败: ${this._cachedBalance.error}`);
+		} else {
+			lines.push("$(loading~spin) 正在获取余额...");
+		}
+
+		lines.push("");
+
+		if (this._totalInputTokens > 0 || this._totalOutputTokens > 0) {
+			lines.push(`📊 本次会话用量 (估算)`);
+			lines.push(`   ├ 输入: ${this._formatTokens(this._totalInputTokens)}`);
+			lines.push(`   └ 输出: ${this._formatTokens(this._totalOutputTokens)}`);
+			lines.push(`   └ 合计: ${this._formatTokens(this._totalInputTokens + this._totalOutputTokens)}`);
+		} else {
+			lines.push("📊 本次会话暂无用量统计");
+		}
+
+		const cached = this._cachedBalance;
+		if (cached && cached.timestamp) {
+			const ago = Math.round((Date.now() - cached.timestamp) / 1000);
+			lines.push("");
+			lines.push(`🕐 余额缓存于 ${this._formatTimeAgo(ago)} 前`);
+		}
+
+		lines.push("");
+		lines.push("点击刷新余额 | 右键管理API Key");
+
+		return lines.join("\n");
+	}
+
+	private _updateDisplay(): void {
+		this._statusBarItem.text = this._buildCompactText();
+		this._statusBarItem.tooltip = new vscode.MarkdownString(this._buildTooltip());
+	}
+
+	private async _refresh(): Promise<void> {
+		try {
+			const apiKey = await this._getApiKey();
+			if (!apiKey) {
+				this._cachedBalance = { timestamp: Date.now(), data: null, error: "未配置 API Key" };
+				this._updateDisplay();
+				return;
+			}
+
+			const data = await fetchBalance(apiKey);
+			this._cachedBalance = { timestamp: Date.now(), data };
+			// Persist to globalState so data survives restarts
+			void this._globalState.update(BALANCE_CACHE_STATE_KEY, this._cachedBalance);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			console.error("[DeepSeek Balance] Fetch failed:", msg);
+			this._cachedBalance = { timestamp: Date.now(), data: null, error: msg };
+		}
+		this._updateDisplay();
+	}
+
+	/** Schedule periodic refresh. */
+	startAutoRefresh(): void {
+		this.stopAutoRefresh();
+		this._refreshTimer = setInterval(() => {
+			void this._refresh();
+		}, REFRESH_INTERVAL_MS);
+	}
+
+	/** Stop periodic refresh (cleanup). */
+	stopAutoRefresh(): void {
+		if (this._refreshTimer) {
+			clearInterval(this._refreshTimer);
+			this._refreshTimer = undefined;
+		}
+	}
+
+	/** Dispose the status bar item and clean up. */
+	dispose(): void {
+		this.stopAutoRefresh();
+		this._statusBarItem.dispose();
+	}
+
+	// ---- formatting helpers ----
+
+	private _formatTokens(n: number): string {
+		if (n >= 1_000_000) {
+			return `${(n / 1_000_000).toFixed(1)}M`;
+		}
+		if (n >= 1_000) {
+			return `${(n / 1_000).toFixed(1)}K`;
+		}
+		return String(n);
+	}
+
+	private _formatTimeAgo(seconds: number): string {
+		if (seconds < 60) {
+			return `${seconds} 秒`;
+		}
+		if (seconds < 3600) {
+			return `${Math.floor(seconds / 60)} 分钟`;
+		}
+		return `${Math.floor(seconds / 3600)} 小时`;
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { HuggingFaceChatModelProvider } from "./provider";
+import { BalanceStatusBarManager } from "./balance";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Build a descriptive User-Agent to help quantify API usage
@@ -12,6 +13,28 @@ export function activate(context: vscode.ExtensionContext) {
 	const provider = new HuggingFaceChatModelProvider(context.secrets, ua, context.globalState);
 	// Register the Hugging Face provider under the vendor id used in package.json
 	vscode.lm.registerLanguageModelChatProvider("huggingface", provider);
+
+	// ── Balance status bar item (bottom-right, like Copilot native UI) ──
+	const balanceManager = new BalanceStatusBarManager(
+		() => Promise.resolve(context.secrets.get("deepseek.apiKey")),
+		context.globalState,
+	);
+	balanceManager.startAutoRefresh();
+
+	// Wire provider → balanceManager so token usage is tracked
+	provider.onUsage = (inputTokens: number, outputTokens: number) => {
+		balanceManager.recordUsage(inputTokens, outputTokens);
+	};
+
+	context.subscriptions.push(balanceManager);
+
+	// Command: refresh balance on demand (accessible via command palette & status bar click)
+	context.subscriptions.push(
+		vscode.commands.registerCommand("huggingface.refreshBalance", async () => {
+			await balanceManager.refresh();
+			vscode.window.showInformationMessage("DeepSeek 余额已刷新");
+		})
+	);
 
 	// Management command to configure API key
 	context.subscriptions.push(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -107,6 +107,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	private _emittedTextToolCallKeys = new Set<string>();
 	private _emittedTextToolCallIds = new Set<string>();
 
+	/** Callback fired after each streaming response completes, for usage tracking. */
+	onUsage: ((inputTokens: number, outputTokens: number) => void) | undefined;
+
 	/**
 	 * Create a provider using the given secret storage for the API key.
 	 * @param secrets VS Code secret storage.
@@ -360,6 +363,18 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			await this.processStreamingResponse(response.body, trackingProgress, token);
 			// Persist reasoning from this turn into the cache for future turns.
 			this.persistReasoningForTurn();
+
+			// ── Usage tracking for status bar ──
+			if (this.onUsage) {
+				// Estimate output tokens from the emitted text + reasoning + tool calls
+				let outputTokens = Math.ceil(this._currentTurnEmittedText.length / 4)
+					+ Math.ceil(this._currentTurnReasoning.length / 4);
+				for (const tc of this._currentTurnEmittedToolCalls) {
+					// Rough estimate: each tool call ~ 50 tokens overhead
+					outputTokens += 50;
+				}
+				this.onUsage(inputTokenCount + toolTokenCount, outputTokens);
+			}
 		} catch (err) {
 			console.error("[Hugging Face Model Provider] Chat request failed", {
 				modelId: model.id,


### PR DESCRIPTION
## Summary
在 VS Code 右下角状态栏显示 DeepSeek 余额和 Token 用量，类似 Copilot 原生 UI。

## Changes
- **新增 `src/balance.ts`** — 余额查询和状态栏管理模块
  - 每 5 分钟自动调用 `GET /user/balance` 获取余额
  - 状态栏紧凑显示 ¥xx.xx（优先 CNY）
  - Hover 浮窗展示详细余额分项 + 会话 Token 用量估算
  - 余额缓存到 globalState，重启 VS Code 后仍然可见
  - 点击状态栏可手动刷新
- **修改 `src/extension.ts`** — 注册 BalanceStatusBarManager 和 refresh 命令
- **修改 `src/provider.ts`** — 新增 onUsage 回调追踪每次 API 调用的 token 用量
- **修改 `package.json`** — 注册 huggingface.refreshBalance 命令

## Screenshots
<!-- 可以附加截图展示状态栏效果 -->

## Related API Doc
https://api-docs.deepseek.com/zh-cn/api/get-user-balance